### PR TITLE
Fix for change constants

### DIFF
--- a/sources/Build/Cons.php
+++ b/sources/Build/Cons.php
@@ -74,7 +74,7 @@ class _Cons extends Singleton
             }
 
             Member::loggedIn()->language()->words[ $tab . '_tab' ] = $tab;
-            $form->add( $key )->label( $key )->empty( $value[ 'current' ] )->description( $value[ 'description' ] ?? null )->tab( $tab );
+            $form->add( $key )->label( $key )->empty( $value[ 'current' ] )->description( $value[ 'description' ] ?? '' )->tab( $tab );
 
             switch ( gettype( $value[ 'current' ] ) ) {
                 case 'boolean':


### PR DESCRIPTION
TypeError: Argument 1 passed to IPS\toolbox\Form\_Element::description() must be of the type string, null given, called in /Users/sviluppo/Documents/sites/448.test/applications/toolbox/sources/Build/Cons.php on line 77 (0)